### PR TITLE
Prepend 'python3' to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ WORKDIR /home/tor
 
 ENV CONFIG_FILE=/home/tor/.vanguards.conf
 
-ENTRYPOINT ["/entrypoint.py"]
+ENTRYPOINT ["python3", "/entrypoint.py"]
 
 CMD python3 /opt/vanguards/src/vanguards.py --config $CONFIG_FILE


### PR DESCRIPTION
This fixed a "No such file or directory execute" issue where the Vanguards container was exiting with code 127 when bringing the containers up after building localhost/vanguards image on Win10.

Haven't tested this on linux, so don't know if it breaks.